### PR TITLE
[Feature] Card drag-and-drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /public/build/
 
 .DS_Store
+
+.vercel

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,10 +1,20 @@
 <script>
   import Board from './Board.svelte';
+  import { version, lists } from './stores.js';
 </script>
 
 <main>
-  <h1>TrellllllllNo!</h1>
-  <Board />
+  {#if $lists.version !== version}
+    This application is currently for demo purposes only.<br />You're running version
+    <pre> {$lists.version}</pre>
+    and this application has been updated to
+    <pre>{version}</pre>
+    .<br /><br />
+    You need to update and reset your saved local session data in order to keep using. Visit dev tools > Application > Local Storage > Clear All.
+  {:else}
+    <h1>TrellllllllNo!</h1>
+    <Board />
+  {/if}
 </main>
 
 <style>
@@ -20,6 +30,12 @@
     text-transform: uppercase;
     font-size: 4em;
     font-weight: 100;
+  }
+
+  pre {
+    display: inline-block;
+    color: #ff3e00;
+    background-color: #efefef;
   }
 
   @media (min-width: 640px) {

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -12,12 +12,12 @@
   function addList() {
     list.id = Math.random();
     list.cards = [];
-    $lists = [...lists.lists, list];
+    $lists.lists = [...$lists.lists, list];
   }
 
   function saveList() {
     if (list.title) {
-      addList(list);
+      addList();
       toggleCreate();
       list = {};
     }

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -11,6 +11,7 @@
 
   function addList() {
     list.id = Math.random();
+    list.cards = [];
     lists.update((lists) => [...lists, list]);
   }
 

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -12,7 +12,7 @@
   function addList() {
     list.id = Math.random();
     list.cards = [];
-    lists.update((lists) => [...lists, list]);
+    $lists = [...lists.lists, list];
   }
 
   function saveList() {
@@ -33,6 +33,7 @@
   }
 
   function keyboardControls(e) {
+    e.stopPropagation();
     if (e.key === 'Enter') {
       e.preventDefault();
       return saveList();
@@ -45,21 +46,21 @@
   }
 
   function handleDndConsiderColumns(e) {
-    $lists = e.detail.items;
+    $lists.lists = e.detail.items;
   }
 
   function handleDndFinalizeColumns(e) {
-    $lists = e.detail.items;
+    $lists.lists = e.detail.items;
   }
 </script>
 
 <ul
-  use:dndzone={{ items: $lists, flipDurationMs, type: 'columns' }}
+  use:dndzone={{ items: $lists.lists, flipDurationMs, type: 'columns' }}
   on:consider={handleDndConsiderColumns}
   on:finalize={handleDndFinalizeColumns}
 >
-  {#each $lists as list (list.id)}
-    <li animate:flip={{ duration: flipDurationMs }}>
+  {#each $lists.lists as list (list.id)}
+    <li animate:flip={{ duration: flipDurationMs }} class="list">
       <h2 contenteditable bind:textContent={list.title} />
       <Cards listId={list.id} />
     </li>
@@ -95,10 +96,14 @@
     text-align: left;
   }
 
-  li {
+  .list {
     background-color: rgb(235, 236, 240);
     border-radius: 3px;
     padding: 10px;
+
+    display: grid;
+    grid-auto-rows: max-content;
+    grid-gap: 10px;
   }
 
   h2 {

--- a/src/Cards.svelte
+++ b/src/Cards.svelte
@@ -10,10 +10,10 @@
   const flipDurationMs = 200;
 
   // Note: if this is not reactive, e.g. const listIndex, we get interesting rendering bugs.
-  $: listIndex = $lists.findIndex((storedList) => storedList.id === listId);
+  $: listIndex = $lists.lists.findIndex((storedList) => storedList.id === listId);
 
   function addCard(card) {
-    $lists[listIndex].cards = [...$lists[listIndex].cards, card];
+    $lists.lists[listIndex].cards = [...$lists.lists[listIndex].cards, card];
   }
 
   function saveCard() {
@@ -34,7 +34,6 @@
   }
 
   function keyboardControls(e) {
-    e.stopPropagation();
     if (e.key === 'Enter') {
       e.preventDefault();
       return saveCard();
@@ -47,40 +46,48 @@
   }
 
   function handleDndConsiderCards(e) {
-    $lists[listIndex].cards = e.detail.items;
+    $lists.lists[listIndex].cards = e.detail.items;
   }
 
   function handleDndFinalizeCards(e) {
-    $lists[listIndex].cards = e.detail.items;
+    $lists.lists[listIndex].cards = e.detail.items;
   }
 </script>
 
 <ul
-  use:dndzone={{ items: $lists[listIndex].cards, flipDurationMs }}
+  class="list"
+  use:dndzone={{ items: $lists.lists[listIndex].cards, flipDurationMs }}
   on:consider={handleDndConsiderCards}
   on:finalize={handleDndFinalizeCards}
 >
-  {#each $lists[listIndex].cards as card (card.id)}
-    <li contenteditable bind:textContent={card.title} animate:flip={{ duration: flipDurationMs }} />
+  {#each $lists.lists[listIndex].cards as card (card.id)}
+    <li animate:flip={{ duration: flipDurationMs }}>
+      <div>{card.title}</div>
+    </li>
   {/each}
+</ul>
+<ul>
   {#if createCardForm}
     <!-- svelte-ignore a11y-autofocus -->
-    <li
-      contenteditable
-      bind:textContent={card.title}
-      autofocus
-      on:keydown={keyboardControls}
-      placeholder="Enter a title for this card..."
-    />
+    <li>
+      <div
+        contenteditable
+        bind:textContent={card.title}
+        autofocus
+        on:keydown={keyboardControls}
+        placeholder="Enter a title for this card..."
+      />
+    </li>
   {/if}
 </ul>
-
-{#if !createCardForm}
-  <button on:click={toggleCreate}>Create Card</button>
-{:else}
-  <button on:click={cancelCard}>Cancel</button>
-  <button on:click={saveCard}>Save</button>
-{/if}
+<div>
+  {#if !createCardForm}
+    <button on:click={toggleCreate}>Create Card</button>
+  {:else}
+    <button on:click={cancelCard}>Cancel</button>
+    <button on:click={saveCard}>Save</button>
+  {/if}
+</div>
 
 <style>
   ul {
@@ -88,18 +95,24 @@
     display: grid;
     grid-auto-rows: max-content;
     grid-gap: 10px;
-    min-height: 200px;
     padding: 0;
+  }
+
+  .list {
+    min-height: 38px;
   }
 
   li {
     background-color: white;
     border-radius: 3px;
     box-shadow: 0 1px 0 rgba(9, 30, 66, 0.25);
+  }
+
+  li div {
     padding: 10px;
   }
 
-  li[placeholder]:empty:before {
+  li div[placeholder]:empty:before {
     color: rgba(0, 0, 0, 0.5);
     content: attr(placeholder);
   }

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,7 +1,12 @@
 import { writable } from 'svelte-persistent-store/local.js';
 
-export const lists = writable('lists', [
-  { title: 'To Do', id: Math.random(), cards: [] },
-  { title: 'Doing', id: Math.random(), cards: [] },
-  { title: 'Done', id: Math.random(), cards: [] },
-])
+export const version = 1.1;
+
+export const lists = writable('lists', {
+  version: 1.1,
+  lists: [
+    { title: 'To Do', id: Math.random(), cards: [] },
+    { title: 'Doing', id: Math.random(), cards: [] },
+    { title: 'Done', id: Math.random(), cards: [] },
+  ],
+});

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,8 +1,7 @@
 import { writable } from 'svelte-persistent-store/local.js';
 
-export const cards = writable('cards', []);
 export const lists = writable('lists', [
-  { title: 'To Do', id: Math.random() },
-  { title: 'Doing', id: Math.random() },
-  { title: 'Done', id: Math.random() },
-]);
+  { title: 'To Do', id: Math.random(), cards: [] },
+  { title: 'Doing', id: Math.random(), cards: [] },
+  { title: 'Done', id: Math.random(), cards: [] },
+])


### PR DESCRIPTION
Adds drag-and-drop functionality to the cards that can be created per list. These cards can be dragged to re-order within their current list, or across other existing lists. The shape of the underlying list and card data needed to be modified to make this work properly.

Additionally, a version check has been added which will inform a user to rest their local session data (automated button forthcoming, potentially).

Minor bug fixes applied.